### PR TITLE
feat: support code-block directive

### DIFF
--- a/rstfmt/rst_extras.py
+++ b/rstfmt/rst_extras.py
@@ -177,6 +177,7 @@ def register() -> None:
     _add_directive('only', sphinx.directives.other.Only)
     _add_directive('highlight', sphinx.directives.code.Highlight)
     _add_directive('todo', sphinx.ext.todo.Todo)
+    _add_directive('code-block', sphinx.directives.code.CodeBlock)
 
     for d in set(_subclasses(sphinx.ext.autodoc.Documenter)):
         if d.objtype != 'object':


### PR DESCRIPTION
This commit adds proper support for the `code-block` directive.

This is motivated by the desire to highlight lines via the `:emphasize-lines:` parameter, which is not possible with `code` blocks: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-option-code-block-emphasize-lines

Currently, if you attempt to run `rstfmt` on a `code-block` containing `:emphasize-lines:`, it results in the following error:
```console
$ rstfmt test.rst
:1: (ERROR/3) Error in "code-block" directive:
unknown option: "emphasize-lines".

.. code-block:: python
   :emphasize-lines: 1
```

Note that this also changes `rstfmt` behavior with regards to `code-block`s without unknown parameters: Without this commit, `rstfmt` replaces any `code-block` it can parse with a `code` block, but with this commit that is no longer the case.